### PR TITLE
add type for QRCode function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,25 @@
+  export function QRCode({
+    content,
+    size,
+    padding,
+    color,
+    gradientDirection,
+    backgroundColor,
+    codeStyle,
+    outerEyeStyle,
+    innerEyeStyle,
+    logoSize,
+    ecl,
+  }: {
+    content?: string;
+    size?: number;
+    padding?: number;
+    color?: string;
+    gradientDirection?: Array<number>;
+    backgroundColor?: string;
+    codeStyle?: string;
+    outerEyeStyle?: string;
+    innerEyeStyle?: string;
+    logoSize?: number;
+    ecl?: string;
+  });


### PR DESCRIPTION
I was finding the library that can use on expo.
thank you for good it.

But, there is not @types.
So I added simple it .